### PR TITLE
fix: don't emit event on disposed messangers

### DIFF
--- a/lib/messenger/index.js
+++ b/lib/messenger/index.js
@@ -149,6 +149,7 @@ function _initializeSubscribers() {
  * Destroys messenger. Maybe needs to unsubscribe all subscribers
  */
 function Messenger$destroy() {
+    this._destroyed = true;
     this.offAll();
     var messageSource = this.getMessageSource();
     if (messageSource)
@@ -586,10 +587,14 @@ function _callSubscriber(subscriber, message, data, callback, _synchronous) {
             subscriber.options.dispatchTimes--;
     }
 
-    if (synchro)
+    if (synchro) {
         subscriber.subscriber.call(subscriber.context, message, data, callback);
-    else
-        _setTimeout(function() { subscriber.subscriber.call(subscriber.context, message, data, callback); }, 0);
+    } else {
+        var messenger = this;
+        _setTimeout(function() {
+            if (!messenger._destroyed) subscriber.subscriber.call(subscriber.context, message, data, callback);
+        }, 0);
+    }
 }
 
 

--- a/test/messenger/benchmark.js
+++ b/test/messenger/benchmark.js
@@ -10,7 +10,7 @@ var _subscriber;
 function subscriber() { _subscriber(); }
 messenger.on('test', subscriber);
 messenger.on(/testing/, subscriber);
- 
+
 
 // 2 june 2015:
 // Message delivery x 345 ops/sec ±1.57% (66 runs sampled)

--- a/test/messenger/index2_test.js
+++ b/test/messenger/index2_test.js
@@ -23,7 +23,8 @@ describe('Messenger class with methods on host class prototype', function() {
         offEvents: 'offMessages',
         post: 'postMessage',
         postMessageSync: 'postMessageSync',
-        getListeners: 'getSubscribers'
+        getListeners: 'getSubscribers',
+        destroy: 'destroy'
     });
 
 

--- a/test/messenger/index_test.js
+++ b/test/messenger/index_test.js
@@ -18,7 +18,8 @@ describe('Messenger class', function() {
             offEvents: 'offMessages',
             post: 'postMessage',
             postMessageSync: 'postMessageSync',
-            getListeners: 'getSubscribers'
+            getListeners: 'getSubscribers',
+            destroy: 'destroy'
         });
         return {host: host, messenger: messenger};
     }

--- a/test/messenger/messenger.js
+++ b/test/messenger/messenger.js
@@ -89,7 +89,7 @@ var messengerTests = module.exports = function(getHostWithMessenger) {
         assert.equal(messenger._messageSubscribers.event3.length, 1, 'event3 has 1 subscriber');
         assert(host.off('event3', handler2), 'handler2 removed from event3');
         assert(Match.test(messenger._messageSubscribers.event3, undefined), 'event3 has no subscribers');
-        
+
         assert(host.off(/test1/), 'remove pattern subscriber');
         assert(Match.test(messenger._patternMessageSubscribers['/test1/'], undefined), 'pattern event is undefined');
     });
@@ -132,10 +132,10 @@ var messengerTests = module.exports = function(getHostWithMessenger) {
                 'event3': handler3
             };
 
-        assert.deepEqual(host.onEvents(events), {event1: true, 'event1 event2': true, event3: true}, 
+        assert.deepEqual(host.onEvents(events), {event1: true, 'event1 event2': true, event3: true},
             'add subscribers with events hash');
         assert(Match.test(messenger._messageSubscribers, Match.ObjectHash([Object])), '_messageSubscribers is set');
-        assert.deepEqual(host.onEvents(events), {event1: false, 'event1 event2': false, event3: false}, 
+        assert.deepEqual(host.onEvents(events), {event1: false, 'event1 event2': false, event3: false},
             'add subscribers with events hash second time');
     });
 
@@ -216,7 +216,7 @@ var messengerTests = module.exports = function(getHostWithMessenger) {
             , messenger = result.messenger
             , postedData = { test: 1 }
             , called = {};
-        
+
         function handler(msg, data) {
             assert.equal(this, host);
             called['handler'] = { msg: msg, data: data };
@@ -257,7 +257,7 @@ var messengerTests = module.exports = function(getHostWithMessenger) {
                     done();
                 }, 20);
             }, 20);
-        }, 20); 
+        }, 20);
     });
 
 
@@ -287,7 +287,7 @@ var messengerTests = module.exports = function(getHostWithMessenger) {
                 { subscriber: handler1, context: host },
                 { subscriber: patternSubscriber, context: host }
             ]);
-        
+
         // pattern subscriber will NOT be included
         var event1_Subscribers = host.getListeners('event1', false);
 
@@ -395,6 +395,46 @@ var messengerTests = module.exports = function(getHostWithMessenger) {
 
         _.delay(function() {
             assert.deepEqual(posted, [{ msg: 'event', data: { test: 1 } }]);
+            done();
+        }, 20);
+    });
+
+    it('should unsubscribe all events when disposed', function () {
+        var result = getHostWithMessenger()
+            , host = result.host
+            , messenger = result.messenger
+            , posted = [];
+
+        function localHandler(msg, data) {
+            posted.push(msg);
+        };
+        function noop() {}
+
+        host.on('event', localHandler);
+        host.destroy();
+        host.postMessageSync('event');
+
+        assert.deepEqual(posted, []);
+    });
+
+    it('should not emit asynchronous events if host is destroyed synchronously', function (done) {
+        var result = getHostWithMessenger()
+            , host = result.host
+            , messenger = result.messenger
+            , posted = [];
+
+        function localHandler(msg, data) {
+            posted.push(msg);
+        };
+        function noop() {}
+
+        host.on('event', localHandler);
+        host.post('event', {}, noop, false);
+        host.destroy();
+
+        assert.deepEqual(posted, []);
+        _.delay(function() {
+            assert.deepEqual(posted, []);
             done();
         }, 20);
     });


### PR DESCRIPTION
Fixes milojs/milo#71

Coverage before

![screen shot 2017-01-27 at 10 47 30](https://cloud.githubusercontent.com/assets/680284/22368472/93302094-e47e-11e6-8e86-347610998c2f.png)

after

![screen shot 2017-01-27 at 10 47 50](https://cloud.githubusercontent.com/assets/680284/22368474/98fbad9a-e47e-11e6-8ba4-4b4c8421a377.png)
